### PR TITLE
rework `actor.Context`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ lint: get-golangcilint
 # Runs tests on entire repo
 .PHONY: test
 test: 
-	go test --race ./...
+	go test --race -count=10 -failfast ./...
 
 # Code tidy
 .PHONY: tidy

--- a/actor/actor_test.go
+++ b/actor/actor_test.go
@@ -11,6 +11,7 @@ import (
 func Test_NewWorker(t *testing.T) {
 	t.Parallel()
 
+	ctx := NewContext()
 	sigC := make(chan struct{}, 1)
 	workerFunc := func(c Context) WorkerStatus {
 		sigC <- struct{}{}
@@ -21,7 +22,7 @@ func Test_NewWorker(t *testing.T) {
 	assert.NotNil(t, w)
 
 	// We assert that worker will delgate call to supplied workerFunc
-	assert.Equal(t, WorkerContinue, w.DoWork(nil))
+	assert.Equal(t, WorkerContinue, w.DoWork(ctx))
 	assert.Len(t, sigC, 1)
 }
 
@@ -183,16 +184,4 @@ func (w *worker) DoWork(c Context) WorkerStatus {
 	case <-c.Done():
 		return WorkerEnd
 	}
-}
-
-func Test_Context(t *testing.T) {
-	t.Parallel()
-
-	ctx := NewContext()
-
-	assert.NotNil(t, ctx.Done())
-	assert.Len(t, ctx.Done(), 0)
-
-	ctx.SignalEnd()
-	assert.Len(t, ctx.Done(), 1)
 }

--- a/actor/context.go
+++ b/actor/context.go
@@ -1,0 +1,66 @@
+package actor
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// Context is provided so Worker can listen and respond on stop signal sent from Actor.
+type Context = context.Context
+
+var ErrStopped = errors.New("actor stopped")
+
+type contextImpl struct {
+	mu    sync.Mutex
+	err   error
+	doneC chan struct{}
+}
+
+func NewContext() *contextImpl { //nolint:revive
+	return &contextImpl{
+		doneC: make(chan struct{}),
+	}
+}
+
+func NewContextEnded() *contextImpl { //nolint:revive
+	doneC := make(chan struct{})
+	close(doneC)
+
+	return &contextImpl{
+		doneC: doneC,
+		err:   ErrStopped,
+	}
+}
+
+func (c *contextImpl) Deadline() (time.Time, bool) {
+	return time.Time{}, false
+}
+
+func (c *contextImpl) signalEnd() {
+	c.mu.Lock()
+	c.err = ErrStopped
+	close(c.doneC)
+	c.mu.Unlock()
+}
+
+func (c *contextImpl) Done() <-chan struct{} {
+	return c.doneC
+}
+
+func (c *contextImpl) Err() error {
+	c.mu.Lock()
+	err := c.err
+	c.mu.Unlock()
+
+	return err
+}
+
+func (*contextImpl) Value(key any) any {
+	return nil
+}
+
+func (c *contextImpl) String() string {
+	return "actor.Context"
+}

--- a/actor/context_export_test.go
+++ b/actor/context_export_test.go
@@ -1,9 +1,5 @@
 package actor
 
-func NewContext() *contextImpl {
-	return newContext()
-}
-
 func (c *contextImpl) SignalEnd() {
 	c.signalEnd()
 }

--- a/actor/context_test.go
+++ b/actor/context_test.go
@@ -1,0 +1,51 @@
+package actor_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/vladopajic/go-actor/actor"
+)
+
+func Test_Context(t *testing.T) {
+	t.Parallel()
+
+	ctx := NewContext()
+	assert.NotNil(t, ctx.Done())
+
+	select {
+	case <-ctx.Done():
+		assert.FailNow(t, "should not be able to read from Done channel")
+	default:
+	}
+
+	assert.NoError(t, ctx.Err())
+
+	ctx.SignalEnd()
+
+	select {
+	case _, ok := <-ctx.Done():
+		assert.False(t, ok)
+	default:
+		assert.FailNow(t, "should be able to read from Done channel")
+	}
+
+	assert.ErrorIs(t, ctx.Err(), ErrStopped)
+}
+
+func Test_Context_Ended(t *testing.T) {
+	t.Parallel()
+
+	ctx := NewContextEnded()
+	assert.NotNil(t, ctx.Done())
+
+	select {
+	case _, ok := <-ctx.Done():
+		assert.False(t, ok)
+	default:
+		assert.FailNow(t, "should be able to read from Done channel")
+	}
+
+	assert.ErrorIs(t, ctx.Err(), ErrStopped)
+}


### PR DESCRIPTION
`actor.Context` now fully implements interface of `context.Context`