### PR TITLE
rename queue method Size to Len

### DIFF
--- a/actor/queue.go
+++ b/actor/queue.go
@@ -32,7 +32,7 @@ func (q *queue[T]) PopFront() T {
 	return q.q.PopFront()
 }
 
-func (q *queue[T]) Size() int {
+func (q *queue[T]) Len() int {
 	return q.q.Len()
 }
 

--- a/actor/queue_test.go
+++ b/actor/queue_test.go
@@ -14,39 +14,39 @@ func TestQueue_Basic(t *testing.T) {
 	q := NewQueue[int](0, 0)
 
 	assert.Equal(t, 0, q.Cap())
-	assert.Equal(t, 0, q.Size())
+	assert.Equal(t, 0, q.Len())
 	assert.True(t, q.IsEmpty())
 
 	// Push 1
 	q.PushBack(1)
-	assert.Equal(t, 1, q.Size())
+	assert.Equal(t, 1, q.Len())
 	assert.False(t, q.IsEmpty())
 
 	// Push 2
 	q.PushBack(2)
-	assert.Equal(t, 2, q.Size())
+	assert.Equal(t, 2, q.Len())
 	assert.False(t, q.IsEmpty())
 
 	// Push 3
 	q.PushBack(3)
 	assert.False(t, q.IsEmpty())
-	assert.Equal(t, 3, q.Size())
+	assert.Equal(t, 3, q.Len())
 	assert.False(t, q.IsEmpty())
 
 	// PopFront (expect 1)
 	assert.Equal(t, 1, q.Front())
 	assert.Equal(t, 1, q.PopFront())
-	assert.Equal(t, 2, q.Size())
+	assert.Equal(t, 2, q.Len())
 
 	// PopFront (expect 2)
 	assert.Equal(t, 2, q.Front())
 	assert.Equal(t, 2, q.PopFront())
-	assert.Equal(t, 1, q.Size())
+	assert.Equal(t, 1, q.Len())
 
 	// PopFront (expect 3)
 	assert.Equal(t, 3, q.Front())
 	assert.Equal(t, 3, q.PopFront())
-	assert.Equal(t, 0, q.Size())
+	assert.Equal(t, 0, q.Len())
 }
 
 func TestQueue_Cap(t *testing.T) {
@@ -55,34 +55,34 @@ func TestQueue_Cap(t *testing.T) {
 	{
 		q := NewQueue[any](0, 10)
 		assert.Equal(t, 0, q.Cap())
-		assert.Equal(t, 0, q.Size())
+		assert.Equal(t, 0, q.Len())
 
 		q.PushBack(`🌊`)
 
 		assert.Equal(t, MinQueueCapacity, q.Cap())
-		assert.Equal(t, 1, q.Size())
+		assert.Equal(t, 1, q.Len())
 	}
 
 	{
 		q := NewQueue[any](10, 10)
 		assert.Equal(t, MinQueueCapacity, q.Cap())
-		assert.Equal(t, 0, q.Size())
+		assert.Equal(t, 0, q.Len())
 	}
 
 	{
 		q := NewQueue[int](MinQueueCapacity*2, 10)
 		assert.Equal(t, MinQueueCapacity*2, q.Cap())
-		assert.Equal(t, 0, q.Size())
+		assert.Equal(t, 0, q.Len())
 	}
 
 	{
 		q := NewQueue[any](0, MinQueueCapacity*2)
 		assert.Equal(t, 0, q.Cap())
-		assert.Equal(t, 0, q.Size())
+		assert.Equal(t, 0, q.Len())
 
 		q.PushBack(`🌊`)
 
 		assert.Equal(t, MinQueueCapacity*2, q.Cap())
-		assert.Equal(t, 1, q.Size())
+		assert.Equal(t, 1, q.Len())
 	}
 }


### PR DESCRIPTION
renamed queue method Size to Len in order to match go's built in function `len`