### PR TITLE
add combined stop

### DIFF
--- a/actor/actor.go
+++ b/actor/actor.go
@@ -167,29 +167,6 @@ func (a *actor) onStop() {
 	}
 }
 
-// Combine returns single Actor which combines all specified actors into one.
-// Calling Start or Stop function on this Actor will invoke respective function
-// on all Actors provided to this function.
-func Combine(actors ...Actor) Actor {
-	return &combinedActor{actors}
-}
-
-type combinedActor struct {
-	actors []Actor
-}
-
-func (a *combinedActor) Stop() {
-	for _, a := range a.actors {
-		a.Stop()
-	}
-}
-
-func (a *combinedActor) Start() {
-	for _, a := range a.actors {
-		a.Start()
-	}
-}
-
 // Idle returns new Actor without Worker.
 func Idle(opt ...Option) Actor {
 	return &idleActor{

--- a/actor/actor_test.go
+++ b/actor/actor_test.go
@@ -266,33 +266,6 @@ func Test_Actor_ContextEndedAfterStop(t *testing.T) {
 	assertContextEnded(t, w.ctx)
 }
 
-// Test asserts that all Start and Stop is
-// delegated to all combined actors.
-func Test_Combine(t *testing.T) {
-	t.Parallel()
-
-	const actorsCount = 5
-
-	onStartC := make(chan any, actorsCount)
-	onStopC := make(chan any, actorsCount)
-	actors := make([]Actor, actorsCount)
-
-	for i := 0; i < actorsCount; i++ {
-		actors[i] = New(newWorker(),
-			OptOnStart(func(Context) { onStartC <- `🌞` }),
-			OptOnStop(func() { onStopC <- `🌚` }),
-		)
-	}
-
-	// Assert that starting and stopping combined actors
-	// will start and stop all individual actors
-	a := Combine(actors...)
-	a.Start()
-	a.Stop()
-	assert.Len(t, onStartC, actorsCount)
-	assert.Len(t, onStopC, actorsCount)
-}
-
 // This test could not assert much, except that test
 // should not panic when Start() and Stop() are called.
 func Test_Noop(t *testing.T) {

--- a/actor/combine.go
+++ b/actor/combine.go
@@ -1,0 +1,96 @@
+package actor
+
+import "sync/atomic"
+
+// Combine returns single Actor which combines all specified actors into one.
+// Calling Start or Stop function on this Actor will invoke respective function
+// on all Actors provided to this function.
+func Combine(actors ...Actor) Actor {
+	return &combinedActor{
+		stopping: &atomic.Bool{},
+		actors:   actors,
+	}
+}
+
+// CombineAndStopTogether returns single Actor which combines all specified actors into one,
+// just like Combine function, and additionally actors combined with this function will end
+// together as soon as any of supplied actors ends.
+func CombineAndStopTogether(actors ...Actor) Actor {
+	combined := &combinedActor{
+		stopping: &atomic.Bool{},
+	}
+
+	combined.actors = wrapActors(actors, combined.Stop)
+
+	return combined
+}
+
+type combinedActor struct {
+	stopping *atomic.Bool
+	actors   []Actor
+}
+
+func (a *combinedActor) Stop() {
+	if !a.stopping.CompareAndSwap(false, true) {
+		return
+	}
+
+	for _, a := range a.actors {
+		a.Stop()
+	}
+}
+
+func (a *combinedActor) Start() {
+	a.stopping.Store(false)
+
+	for _, a := range a.actors {
+		a.Start()
+	}
+}
+
+func wrapActors(actors []Actor, onStop func()) []Actor {
+	wrapActorStruct := func(a *actor) *actor {
+		prevOnStopFunc := a.options.Actor.OnStopFunc
+		a.options.Actor.OnStopFunc = func() {
+			if prevOnStopFunc != nil {
+				prevOnStopFunc()
+			}
+
+			go onStop()
+		}
+
+		return a
+	}
+
+	wrapActorInterface := func(a Actor) Actor {
+		return &wrappedActor{
+			actor:    a,
+			onStopFn: onStop,
+		}
+	}
+
+	for i, a := range actors {
+		switch v := a.(type) {
+		case *actor:
+			actors[i] = wrapActorStruct(v)
+		default:
+			actors[i] = wrapActorInterface(v)
+		}
+	}
+
+	return actors
+}
+
+type wrappedActor struct {
+	actor    Actor
+	onStopFn func()
+}
+
+func (a *wrappedActor) Start() {
+	a.actor.Start()
+}
+
+func (a *wrappedActor) Stop() {
+	a.actor.Stop()
+	go a.onStopFn()
+}

--- a/actor/combine_test.go
+++ b/actor/combine_test.go
@@ -1,0 +1,75 @@
+package actor_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/vladopajic/go-actor/actor"
+)
+
+// Test asserts that all Start and Stop is
+// delegated to all combined actors.
+func Test_Combine(t *testing.T) {
+	t.Parallel()
+
+	const actorsCount = 5
+
+	onStartC := make(chan any, actorsCount)
+	onStopC := make(chan any, actorsCount)
+	actors := make([]Actor, actorsCount)
+
+	for i := 0; i < actorsCount; i++ {
+		actors[i] = New(newWorker(),
+			OptOnStart(func(Context) { onStartC <- `🌞` }),
+			OptOnStop(func() { onStopC <- `🌚` }),
+		)
+	}
+
+	// Assert that starting and stopping combined actors
+	// will start and stop all individual actors
+	a := Combine(actors...)
+
+	// Start combined actor and wait for all actors to be started
+	a.Start()
+	drainC(onStartC, actorsCount)
+
+	// Stopping actor and assert that onStopC has received signal from all actors.
+	// Channel onStopC is not drained intentionally because after Stop() has returned
+	// it is guarantied that all actors have ended.
+	a.Stop()
+	assert.Len(t, onStopC, actorsCount)
+}
+
+// Test_CombineAndStopTogether asserts that all actors will end as soon
+// as first actors ends.
+func Test_CombineAndStopTogether(t *testing.T) {
+	t.Parallel()
+
+	const actorsCount = 5
+
+	onStartC := make(chan any, actorsCount)
+	onStopC := make(chan any, actorsCount)
+	actors := make([]Actor, actorsCount)
+
+	onStart := OptOnStart(func(Context) { onStartC <- `🌞` })
+	onStop := OptOnStop(func() { onStopC <- `🌚` })
+
+	for i := 0; i < actorsCount; i++ {
+		if i%2 == 0 { // case with actorStruct wrapper
+			actors[i] = New(newWorker(), onStart, onStop)
+		} else { // case with actorInterface wrapper
+			actors[i] = Idle(onStart, onStop)
+		}
+	}
+
+	a := CombineAndStopTogether(actors...)
+
+	a.Start()
+	drainC(onStartC, actorsCount)
+
+	// Stop random actor and assert that all actors will be stopped
+	actors[rand.Int31n(actorsCount)].Stop() //nolint:gosec // weak random is fine
+	drainC(onStopC, actorsCount)
+}

--- a/actor/helpers_test.go
+++ b/actor/helpers_test.go
@@ -1,0 +1,7 @@
+package actor_test
+
+func drainC(c <-chan any, count int) {
+	for i := 0; i < count; i++ {
+		<-c
+	}
+}

--- a/actor/test_helpers.go
+++ b/actor/test_helpers.go
@@ -30,7 +30,7 @@ func AssertStartStopAtRandom(t *testing.T, a Actor) {
 	assert.NotNil(t, a)
 
 	for i := 0; i < 1000; i++ {
-		if rand.Int()%2 == 0 { //nolint:gosec // realx
+		if rand.Int()%2 == 0 { //nolint:gosec // weak random is fine
 			a.Start()
 		} else {
 			a.Stop()


### PR DESCRIPTION
add `CombineAndStopTogether` functionality that will stop all combined actors as soon as any of actors is stopped.