### PR TITLE
Add async and closed handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 cover.out
 cover.html
+/vendor

--- a/actor/mailbox.go
+++ b/actor/mailbox.go
@@ -100,7 +100,7 @@ func NewMailbox[T any](opt ...MailboxOption) Mailbox[T] {
 
 		return &mailboxSync[T]{
 			Actor: Idle(OptOnStop(func() {
-				// If KeepChannelsOpen is false (default), close the channel
+				// If DontPanicOnStop is false (default), close the channel
 				if !options.DontPanicOnStop {
 					close(c)
 				}

--- a/actor/mailbox.go
+++ b/actor/mailbox.go
@@ -175,7 +175,7 @@ func (m *mailbox[T]) Stop() {
 	}
 
 	m.running = false
-	m.sendHandler.Store(createPanicHandler[T]("unable to send to a stopped Mailbox"))
+	m.sendHandler.Store(createNoopHandler[T]())
 	m.actor.Stop()
 }
 
@@ -187,6 +187,12 @@ func (m *mailbox[T]) Send(ctx Context, msg T) error {
 func createPanicHandler[T any](msg string) sendHandler[T] {
 	return func(_ Context, _ T) error {
 		panic(msg) //nolint:forbidigo // panic is intentional
+	}
+}
+
+func createNoopHandler[T any]() sendHandler[T] {
+	return func(_ Context, _ T) error {
+		return nil
 	}
 }
 

--- a/actor/mailbox.go
+++ b/actor/mailbox.go
@@ -219,8 +219,10 @@ func createNoopHandler[T any]() sendHandler[T] {
 			// This needs to be run in a separate goroutine
 			// to avoid blocking the caller, to simulate a normal call.
 			go s.Notify(fmt.Errorf("unable to send to a stopped Mailbox"))
+			// The error will come from the notify command, this prevents from sending on a closed channel.
+			return nil
 		}
-		return nil
+		return fmt.Errorf("unable to send to a stopped Mailbox")
 	}
 }
 

--- a/actor/mailbox.go
+++ b/actor/mailbox.go
@@ -153,8 +153,7 @@ type mailbox[T any] struct {
 	actor    Actor
 	sendC    chan<- T
 	receiveC <-chan T
-	underlying Go channels
-	// for the Mailbox are not closed when the Mailbox is stopped
+
 	running         bool
 	lock            sync.Mutex
 	sendHandler     *atomic.Value

--- a/actor/mailbox_test.go
+++ b/actor/mailbox_test.go
@@ -290,7 +290,7 @@ func Test_Mailbox_OptEndAferReceivingAll(t *testing.T) {
 	})
 }
 
-func Test_MailboxOptKeepChannelsOpen(t *testing.T) {
+func Test_MailboxOptDontPanicOnStop(t *testing.T) {
 	t.Parallel()
 
 	m := NewMailbox[any](OptDontPanicOnStop())

--- a/actor/mailbox_test.go
+++ b/actor/mailbox_test.go
@@ -292,6 +292,18 @@ func Test_Mailbox_OptEndAferReceivingAll(t *testing.T) {
 	})
 }
 
+func Test_MailboxOptKeepChannelsOpen(t *testing.T) {
+	t.Parallel()
+
+	m := NewMailbox[any](OptOnKeepChannelOpen())
+	m.Start()
+	assertSendReceive(t, m, "test")
+
+	m.Stop()
+	// This should not panic.
+	assert.NoError(t, m.Send(ContextStarted(), "send to no where"))
+}
+
 func assertSendReceive(t *testing.T, m Mailbox[any], val any) {
 	t.Helper()
 

--- a/actor/mailbox_test.go
+++ b/actor/mailbox_test.go
@@ -204,7 +204,6 @@ func Test_MailboxOptAsChan(t *testing.T) {
 		assertMailboxChannelsClosed(t, m)
 
 	})
-
 	t.Run("non zero cap", func(t *testing.T) {
 		t.Parallel()
 
@@ -298,8 +297,8 @@ func Test_MailboxOptDontPanicOnStop(t *testing.T) {
 	assertSendReceive(t, m, "test")
 
 	m.Stop()
-	// This should not panic.
-	assert.NoError(t, m.Send(ContextStarted(), "send to no where"))
+	// This should not panic but instead return error.
+	assert.Error(t, m.Send(ContextStarted(), "send to no where"))
 }
 
 func assertSendReceive(t *testing.T, m Mailbox[any], val any) {

--- a/actor/mailbox_test.go
+++ b/actor/mailbox_test.go
@@ -193,7 +193,7 @@ func Test_MailboxOptAsChan(t *testing.T) {
 		assertSendBlocking(t, m)
 		assertReceiveBlocking(t, m)
 
-		// Send when there is receiNoErrorver
+		// Send when there is receiver
 		go func() {
 			assert.NoError(t, m.Send(ContextStarted(), `🌹`))
 		}()
@@ -293,7 +293,7 @@ func Test_Mailbox_OptEndAferReceivingAll(t *testing.T) {
 func Test_MailboxOptKeepChannelsOpen(t *testing.T) {
 	t.Parallel()
 
-	m := NewMailbox[any](OptOnKeepChannelOpen())
+	m := NewMailbox[any](OptDontPanicOnStop())
 	m.Start()
 	assertSendReceive(t, m, "test")
 

--- a/actor/mailbox_test.go
+++ b/actor/mailbox_test.go
@@ -1,7 +1,6 @@
 package actor_test
 
 import (
-	gocontext "context"
 	"sync"
 	"testing"
 	"time"
@@ -96,20 +95,6 @@ func Test_Mailbox_SendWithEndedCtx(t *testing.T) {
 	}
 }
 
-func Test_Mailbox_SendWithStoppedMailbox(t *testing.T) {
-	t.Parallel()
-
-	m := NewMailbox[any]()
-
-	m.Start()
-
-	err := m.Send(gocontext.Background(), `🌹`)
-	assert.NoError(t, err)
-	m.Stop()
-	err = m.Send(gocontext.Background(), `🌹`)
-	assert.NoError(t, err)
-}
-
 func Test_FromMailboxes(t *testing.T) {
 	t.Parallel()
 
@@ -199,7 +184,7 @@ func Test_MailboxOptAsChan(t *testing.T) {
 		assertSendBlocking(t, m)
 		assertReceiveBlocking(t, m)
 
-		// Send when there is receiver
+		// Send when there is receiNoErrorver
 		go func() {
 			assert.NoError(t, m.Send(ContextStarted(), `🌹`))
 		}()

--- a/actor/options.go
+++ b/actor/options.go
@@ -130,6 +130,14 @@ func OptOnStartCombined(f func(Context)) CombinedOption {
 	}
 }
 
+// OptOnKeepChannelOpen ensures that the underlying Go channels
+// for the Mailbox are not closed when the Mailbox is stopped.
+func OptOnKeepChannelOpen() MailboxOption {
+	return func(o *options) {
+		o.Mailbox.KeepChannelsOpen = true
+	}
+}
+
 type (
 	option func(o *options)
 
@@ -159,6 +167,7 @@ type optionsMailbox struct {
 	AsChan                bool
 	Capacity              int
 	StopAfterReceivingAll bool
+	KeepChannelsOpen      bool
 }
 
 func newOptions[T ~func(o *options)](opts []T) options {

--- a/actor/options.go
+++ b/actor/options.go
@@ -130,11 +130,10 @@ func OptOnStartCombined(f func(Context)) CombinedOption {
 	}
 }
 
-// OptOnKeepChannelOpen ensures that the underlying Go channels
-// for the Mailbox are not closed when the Mailbox is stopped.
-func OptOnKeepChannelOpen() MailboxOption {
+// OptDontPanicOnStop ensures that the mailbox doesn't panic when stopped.
+func OptDontPanicOnStop() MailboxOption {
 	return func(o *options) {
-		o.Mailbox.KeepChannelsOpen = true
+		o.Mailbox.DontPanicOnStop = true
 	}
 }
 
@@ -167,7 +166,7 @@ type optionsMailbox struct {
 	AsChan                bool
 	Capacity              int
 	StopAfterReceivingAll bool
-	KeepChannelsOpen      bool
+	DontPanicOnStop       bool
 }
 
 func newOptions[T ~func(o *options)](opts []T) options {

--- a/actor/options_test.go
+++ b/actor/options_test.go
@@ -78,8 +78,8 @@ func testMailboxOptions(t *testing.T) {
 	}
 
 	{ // Assert that OptStopAfterReceivingAll will be set
-		opts := NewOptions(OptOnKeepChannelOpen())
-		assert.True(t, opts.Mailbox.KeepChannelsOpen)
+		opts := NewOptions(OptDontPanicOnStop())
+		assert.True(t, opts.Mailbox.DontPanicOnStop)
 
 		assert.Empty(t, opts.Actor)
 		assert.Empty(t, opts.Combined)

--- a/actor/options_test.go
+++ b/actor/options_test.go
@@ -76,6 +76,14 @@ func testMailboxOptions(t *testing.T) {
 		assert.Empty(t, opts.Actor)
 		assert.Empty(t, opts.Combined)
 	}
+
+	{ // Assert that OptStopAfterReceivingAll will be set
+		opts := NewOptions(OptOnKeepChannelOpen())
+		assert.True(t, opts.Mailbox.KeepChannelsOpen)
+
+		assert.Empty(t, opts.Actor)
+		assert.Empty(t, opts.Combined)
+	}
 }
 
 func testCombinedOptions(t *testing.T) {

--- a/actor/sync_mailbox.go
+++ b/actor/sync_mailbox.go
@@ -26,7 +26,7 @@ func (sm *SyncMailbox[T]) ReceiveC() <-chan *Callback[T] {
 }
 
 func (sm *SyncMailbox[T]) Send(ctx gocontext.Context, value T) error {
-	done := make(chan error)
+	done := make(chan error, 1)
 	defer close(done)
 	err := sm.mbx.Send(ctx, &Callback[T]{
 		Value: value,

--- a/actor/sync_mailbox.go
+++ b/actor/sync_mailbox.go
@@ -1,0 +1,50 @@
+package actor
+
+import gocontext "context"
+
+// SyncMailbox is used to synchronously send data, and wait for it to process before returning.
+type SyncMailbox[T any] struct {
+	mbx Mailbox[Callback[T]]
+}
+
+func NewSyncMailbox[T any]() *SyncMailbox[T] {
+	return &SyncMailbox[T]{
+		mbx: NewMailbox[Callback[T]](),
+	}
+}
+
+func (sm *SyncMailbox[T]) Start() {
+	sm.mbx.Start()
+}
+
+func (sm *SyncMailbox[T]) Stop() {
+	sm.mbx.Stop()
+}
+
+func (sm *SyncMailbox[T]) ReceiveC() <-chan Callback[T] {
+	return sm.mbx.ReceiveC()
+}
+
+func (sm *SyncMailbox[T]) Send(ctx gocontext.Context, value T) error {
+	done := make(chan struct{})
+	defer close(done)
+	err := sm.mbx.Send(ctx, Callback[T]{
+		Value: value,
+		done:  done,
+	})
+	if err != nil {
+		return err
+	}
+	<-done
+	return nil
+}
+
+type Callback[T any] struct {
+	Value T
+	done  chan struct{}
+}
+
+// Notify must be called to return the synchronous call.
+func (c *Callback[T]) Notify() {
+	c.done <- struct{}{}
+}

--- a/actor/sync_mailbox_test.go
+++ b/actor/sync_mailbox_test.go
@@ -42,7 +42,7 @@ func Test_SyncMailbox_Basic(t *testing.T) {
 	assert.Equal(t, []string{"hello", "world"}, received)
 }
 
-func Test_SyncMailbox_OptionsKeepChannelsOpen(t *testing.T) {
+func Test_SyncMailbox_OptionsDontPanicOnStop(t *testing.T) {
 	t.Parallel()
 
 	m := NewSyncMailbox[string](OptDontPanicOnStop())
@@ -69,7 +69,7 @@ func Test_SyncMailbox_StopBeforeSend(t *testing.T) {
 	})
 }
 
-func Test_SyncMailbox_StopBeforeSendWithOptKeepChannelsOpen(t *testing.T) {
+func Test_SyncMailbox_StopBeforeSendWithOptDontPanicOnStop(t *testing.T) {
 	t.Parallel()
 
 	m := NewSyncMailbox[string](OptDontPanicOnStop())

--- a/actor/sync_mailbox_test.go
+++ b/actor/sync_mailbox_test.go
@@ -1,0 +1,130 @@
+package actor_test
+
+import (
+	gocontext "context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	. "github.com/vladopajic/go-actor/actor"
+)
+
+func Test_SyncMailbox_Basic(t *testing.T) {
+	t.Parallel()
+
+	m := NewSyncMailbox[string]()
+	assert.NotNil(t, m)
+
+	m.Start()
+	defer m.Stop()
+
+	// Set up receiver
+	var received []string
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		for cb := range m.ReceiveC() {
+			received = append(received, cb.Value)
+			cb.Notify(nil)
+		}
+	}()
+
+	// Test sending multiple messages
+	ctx := gocontext.Background()
+	assert.NoError(t, m.Send(ctx, "hello"))
+	assert.NoError(t, m.Send(ctx, "world"))
+
+	m.Stop()
+	wg.Wait()
+
+	assert.Equal(t, []string{"hello", "world"}, received)
+}
+
+func Test_SyncMailbox_OptionsKeepChannelsOpen(t *testing.T) {
+	t.Parallel()
+
+	m := NewSyncMailbox[string](OptOnKeepChannelOpen())
+	assert.NotNil(t, m)
+
+	m.Start()
+	m.Stop()
+
+	// Test sending multiple messages
+	ctx := gocontext.Background()
+	assert.Error(t, m.Send(ctx, "hello"))
+}
+
+func Test_SyncMailbox_StopBeforeSend(t *testing.T) {
+	t.Parallel()
+
+	m := NewSyncMailbox[string]()
+	assert.NotNil(t, m)
+
+	m.Stop()
+	// Don't start the mailbox at all
+	assert.Panics(t, func() {
+		m.Send(gocontext.Background(), "should fail")
+	})
+}
+
+func Test_SyncMailbox_StopBeforeSendWithOptKeepChannelsOpen(t *testing.T) {
+	t.Parallel()
+
+	m := NewSyncMailbox[string](OptOnKeepChannelOpen())
+	assert.NotNil(t, m)
+
+	m.Start()
+	m.Stop()
+	err := m.Send(gocontext.Background(), "should fail")
+	assert.Error(t, err)
+}
+
+func Test_SyncMailbox_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	m := NewSyncMailbox[int]()
+	assert.NotNil(t, m)
+
+	m.Start()
+	defer m.Stop()
+
+	// Set up receiver
+	var received []int
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		for cb := range m.ReceiveC() {
+			mu.Lock()
+			received = append(received, cb.Value)
+			mu.Unlock()
+			cb.Notify(nil)
+		}
+	}()
+
+	// Send concurrently
+	const numSenders = 10
+	const messagesPerSender = 100
+	var sendWg sync.WaitGroup
+	sendWg.Add(numSenders)
+
+	for i := 0; i < numSenders; i++ {
+		go func(senderID int) {
+			defer sendWg.Done()
+			for j := 0; j < messagesPerSender; j++ {
+				value := senderID*messagesPerSender + j
+				assert.NoError(t, m.Send(gocontext.Background(), value))
+			}
+		}(i)
+	}
+
+	sendWg.Wait()
+	m.Stop()
+	wg.Wait()
+
+	assert.Equal(t, numSenders*messagesPerSender, len(received))
+}

--- a/actor/sync_mailbox_test.go
+++ b/actor/sync_mailbox_test.go
@@ -45,7 +45,7 @@ func Test_SyncMailbox_Basic(t *testing.T) {
 func Test_SyncMailbox_OptionsKeepChannelsOpen(t *testing.T) {
 	t.Parallel()
 
-	m := NewSyncMailbox[string](OptOnKeepChannelOpen())
+	m := NewSyncMailbox[string](OptDontPanicOnStop())
 	assert.NotNil(t, m)
 
 	m.Start()
@@ -72,7 +72,7 @@ func Test_SyncMailbox_StopBeforeSend(t *testing.T) {
 func Test_SyncMailbox_StopBeforeSendWithOptKeepChannelsOpen(t *testing.T) {
 	t.Parallel()
 
-	m := NewSyncMailbox[string](OptOnKeepChannelOpen())
+	m := NewSyncMailbox[string](OptDontPanicOnStop())
 	assert.NotNil(t, m)
 
 	m.Start()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vladopajic/go-actor
 
-go 1.22.7
+go 1.23
 
 require (
 	github.com/gammazero/deque v0.2.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vladopajic/go-actor
 
-go 1.23
+go 1.22.7
 
 require (
 	github.com/gammazero/deque v0.2.1


### PR DESCRIPTION
Wanted to get your thoughts on two features:

Support for SynchronousMailboxes and the ability to not panic on sending to a closed channels. I have a situation where I have an unknown number of callers, and if sending to a stopped Mailbox I would rather it return an error than panic. `DontPanicOnStop` is a terrible name but nothing else seemed better.