### PR TITLE
fix: OptOnStopCombined not called when there was 1 actor combined

### DIFF
--- a/actor/combine.go
+++ b/actor/combine.go
@@ -108,7 +108,6 @@ func (a *combinedActor) Stop() {
 		a.ctx = nil
 	}
 
-	a.running = false
 	a.runningLock.Unlock()
 
 	for _, actor := range a.actors {

--- a/actor/combine_test.go
+++ b/actor/combine_test.go
@@ -78,11 +78,16 @@ func Test_Combine_OptStopTogether(t *testing.T) {
 func Test_Combine_OptOnStopOptOnStart(t *testing.T) {
 	t.Parallel()
 
-	const actorsCount = 5
+	testCombineOptOnStopOptOnStart(t, 1)
+	testCombineOptOnStopOptOnStart(t, 5)
+}
+
+func testCombineOptOnStopOptOnStart(t *testing.T, count int) {
+	t.Helper()
 
 	onStatC, onStartOpt := createCombinedOnStartOption(t, 1)
 	onStopC, onStopOpt := createCombinedOnStopOption(t, 1)
-	actors := createActors(actorsCount)
+	actors := createActors(count)
 
 	a := Combine(actors...).
 		WithOptions(onStopOpt, onStartOpt).
@@ -96,6 +101,8 @@ func Test_Combine_OptOnStopOptOnStart(t *testing.T) {
 	a.Stop() // should have no effect
 	assert.Equal(t, `🌚`, <-onStopC)
 	assert.Equal(t, `🌞`, <-onStatC)
+	assert.Empty(t, onStopC)
+	assert.Empty(t, onStatC)
 }
 
 func Test_Combine_OptOnStop_AfterActorStops(t *testing.T) {


### PR DESCRIPTION
`OptOnStopCombined` was not called when there was 1 actor in actors list in `actor.Combine(actors...)`. 

in this PR this issue was fixed.