### PR TITLE
reduced version of go down to v1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vladopajic/go-actor
 
-go 1.23
+go 1.22
 
 require (
 	github.com/gammazero/deque v1.0.0


### PR DESCRIPTION
since library was not using anything from v1.23 go version was reduced to v1.22.