### PR TITLE
fix(combine): set total running count before starting all

### DIFF
--- a/actor/combine.go
+++ b/actor/combine.go
@@ -66,7 +66,7 @@ type combinedActor struct {
 	stopTogether bool
 
 	ctx          *context
-	runningCount atomic.Int32
+	runningCount atomic.Int64
 	running      bool
 	runningLock  sync.Mutex
 	stopping     *atomic.Bool
@@ -128,6 +128,7 @@ func (a *combinedActor) Start() {
 	a.ctx = ctx
 	a.stopping.Store(false)
 	a.running = true
+	a.runningCount.Add(int64(len(a.actors)))
 
 	a.runningLock.Unlock()
 
@@ -136,7 +137,6 @@ func (a *combinedActor) Start() {
 	}
 
 	for _, actor := range a.actors {
-		a.runningCount.Add(1)
 		actor.Start()
 	}
 }


### PR DESCRIPTION
it is slightly better to set `runningCount` before underlay actors are started. because it can prevent potential race condition (which could happen vaaaaaaary rarely).

1. `combine.Start()` has started first actor and there are more actors to start
2. the first started actor exits early 
   - this will call `onActorStopped` which will set `a.running=false` (because `a.running = runningCount != 0`)
3. this is not good, because `a.running=false` and will get combined actor in inconsistent state because it will be marked as stopped and  `combine.Start()`  will still have more actors to start.