### PR TITLE
feat(combine): stop in parallel 

### DIFF
--- a/actor/combine.go
+++ b/actor/combine.go
@@ -125,6 +125,7 @@ func (a *combinedActor) Stop() {
 func stopAllParallel(actors []Actor) {
 	wg := sync.WaitGroup{}
 	wg.Add(len(actors))
+	defer wg.Wait()
 
 	for _, actor := range actors {
 		go func() {
@@ -132,8 +133,6 @@ func stopAllParallel(actors []Actor) {
 			wg.Done()
 		}()
 	}
-
-	wg.Wait()
 }
 
 func (a *combinedActor) Start() {

--- a/actor/combine.go
+++ b/actor/combine.go
@@ -110,22 +110,7 @@ func (a *combinedActor) Stop() {
 	if a.options.StopParallel {
 		stopAllParallel(a.actors)
 	} else {
-		for _, actor := range a.actors {
-			actor.Stop()
-		}
-	}
-}
-
-func stopAllParallel(actors []Actor) {
-	wg := sync.WaitGroup{}
-	wg.Add(len(actors))
-	defer wg.Wait()
-
-	for _, actor := range actors {
-		go func() {
-			actor.Stop()
-			wg.Done()
-		}()
+		stopAll(a.actors)
 	}
 }
 
@@ -149,8 +134,31 @@ func (a *combinedActor) Start() {
 		fn(ctx)
 	}
 
-	for _, actor := range a.actors {
-		actor.Start()
+	startAll(a.actors)
+}
+
+func startAll(actors []Actor) {
+	for _, a := range actors {
+		a.Start()
+	}
+}
+
+func stopAll(actors []Actor) {
+	for _, a := range actors {
+		a.Stop()
+	}
+}
+
+func stopAllParallel(actors []Actor) {
+	wg := sync.WaitGroup{}
+	wg.Add(len(actors))
+	defer wg.Wait()
+
+	for _, a := range actors {
+		go func() {
+			a.Stop()
+			wg.Done()
+		}()
 	}
 }
 

--- a/actor/options.go
+++ b/actor/options.go
@@ -103,6 +103,12 @@ func OptStopTogether() CombinedOption {
 	}
 }
 
+func OptStopParallel() CombinedOption {
+	return func(o *options) {
+		o.Combined.StopParallel = true
+	}
+}
+
 // OptOnStopCombined registers a function to be executed after
 // all combined Actors have been stopped.
 //
@@ -151,6 +157,7 @@ type optionsActor struct {
 
 type optionsCombined struct {
 	StopTogether bool
+	StopParallel bool
 	OnStopFunc   func()
 	OnStartFunc  func(Context)
 }

--- a/actor/options.go
+++ b/actor/options.go
@@ -103,6 +103,9 @@ func OptStopTogether() CombinedOption {
 	}
 }
 
+// OptStopParallel will stop all combined actors simultaneously.
+// By default, actors are stopped sequentially in order in which they are provided
+// to Combine. In both cases Combine actor will block until all actors have stopped.
 func OptStopParallel() CombinedOption {
 	return func(o *options) {
 		o.Combined.StopParallel = true

--- a/actor/options.go
+++ b/actor/options.go
@@ -103,9 +103,14 @@ func OptStopTogether() CombinedOption {
 	}
 }
 
-// OptStopParallel will stop all combined actors simultaneously.
-// By default, actors are stopped sequentially in order in which they are provided
-// to Combine. In both cases Combine actor will block until all actors have stopped.
+// OptStopParallel ensures that all combined actors stop simultaneously.
+//
+// By default, actors are stopped sequentially in the order they were provided to
+// Combine(...). This means that actors later in the list must wait for the
+// preceding actors to stop. With OptStopParallel option enabled, all actors stop
+// simultaneously without waiting for others.
+//
+// In both cases, the Combine actor will block until all actors have stopped.
 func OptStopParallel() CombinedOption {
 	return func(o *options) {
 		o.Combined.StopParallel = true


### PR DESCRIPTION
add `OptStopParallel` option that gives `Combine` actor ability to stop all actors in parallel.