### PR TITLE
chore(combine): avoid unecessery atomic value

### DIFF
--- a/actor/combine.go
+++ b/actor/combine.go
@@ -71,8 +71,8 @@ type combinedActor struct {
 func (a *combinedActor) onActorStopped() {
 	a.runningLock.Lock()
 
-	a.runningCount -= 1
-	runningCount := a.runningCount
+	a.runningCount--
+	noRunningActors := a.runningCount == 0
 
 	wasRunning := a.running
 	a.running = a.runningCount != 0
@@ -80,7 +80,7 @@ func (a *combinedActor) onActorStopped() {
 	a.runningLock.Unlock()
 
 	// Last actor to end should call onStopFunc
-	if runningCount == 0 && wasRunning && a.options.OnStopFunc != nil {
+	if noRunningActors && wasRunning && a.options.OnStopFunc != nil {
 		a.options.OnStopFunc()
 	}
 

--- a/actor/combine.go
+++ b/actor/combine.go
@@ -62,7 +62,7 @@ type combinedActor struct {
 	options optionsCombined
 
 	ctx          *context
-	runningCount atomic.Int64
+	runningCount int
 	running      bool
 	runningLock  sync.Mutex
 	stopping     *atomic.Bool
@@ -71,9 +71,11 @@ type combinedActor struct {
 func (a *combinedActor) onActorStopped() {
 	a.runningLock.Lock()
 
-	runningCount := a.runningCount.Add(-1)
+	a.runningCount -= 1
+	runningCount := a.runningCount
+
 	wasRunning := a.running
-	a.running = runningCount != 0
+	a.running = a.runningCount != 0
 
 	a.runningLock.Unlock()
 
@@ -126,7 +128,7 @@ func (a *combinedActor) Start() {
 	a.ctx = ctx
 	a.stopping.Store(false)
 	a.running = true
-	a.runningCount.Add(int64(len(a.actors)))
+	a.runningCount += len(a.actors)
 
 	a.runningLock.Unlock()
 


### PR DESCRIPTION
`runningCount` is already protected by `runningLock`, therfore atomic value is not necessary.