### PR TITLE
fix(mailbox-chan): decrementing `ongoingSend` explicitly before returning

### DIFF
--- a/actor/mailbox.go
+++ b/actor/mailbox.go
@@ -173,6 +173,7 @@ func (m *mailboxChan[T]) Send(ctx Context, msg T) error {
 		if m.ongoingSend.Add(-1) == 0 {
 			m.closeOnce.Do(func() { close(m.c) })
 		}
+
 		return fmt.Errorf("Mailbox.Send canceled: %w", ErrMailboxStopped)
 	case <-ctx.Done():
 		m.ongoingSend.Add(-1)

--- a/actor/mailbox.go
+++ b/actor/mailbox.go
@@ -167,15 +167,18 @@ func (m *mailboxChan[T]) Send(ctx Context, msg T) error {
 	}
 
 	m.ongoingSend.Add(1)
-	defer m.ongoingSend.Add(-1)
 
 	select {
 	case <-m.stopSigC:
-		defer m.closeReceiveC()
+		if m.ongoingSend.Add(-1) == 0 {
+			m.closeOnce.Do(func() { close(m.c) })
+		}
 		return fmt.Errorf("Mailbox.Send canceled: %w", ErrMailboxStopped)
 	case <-ctx.Done():
+		m.ongoingSend.Add(-1)
 		return fmt.Errorf("Mailbox.Send canceled: %w", ctx.Err())
 	case m.c <- msg:
+		m.ongoingSend.Add(-1)
 		return nil
 	}
 }

--- a/actor/mailbox_test.go
+++ b/actor/mailbox_test.go
@@ -278,6 +278,47 @@ func Test_Mailbox_AsChan_SendStopped(t *testing.T) {
 	assert.ErrorIs(t, <-sendResultC, ErrMailboxStopped, "Send() should result with error")
 }
 
+// Test asserts that ReceiveC() is closed after Stop() is called while one or more
+// Send() calls are concurrently blocked. This covers the defer-ordering race where
+// closeReceiveC() ran before ongoingSend.Add(-1), leaving the channel permanently open.
+func Test_Mailbox_AsChan_ReceiveCClosedAfterStopDuringSend(t *testing.T) {
+	t.Parallel()
+
+	const senderCount = 10
+
+	m := NewMailbox[any](OptAsChan())
+	m.Start()
+
+	allBlockedC := make(chan struct{})
+	sendResultC := make(chan error, senderCount)
+
+	for range senderCount {
+		go func() {
+			sendResultC <- m.Send(ContextStarted(), `🌹`)
+		}()
+	}
+
+	// Give goroutines time to block inside Send before calling Stop.
+	go func() {
+		time.Sleep(time.Millisecond * 100) //nolint:forbidigo // explained above
+		close(allBlockedC)
+	}()
+
+	<-allBlockedC
+	m.Stop()
+
+	for range senderCount {
+		assert.ErrorIs(t, <-sendResultC, ErrMailboxStopped)
+	}
+
+	select {
+	case _, ok := <-m.ReceiveC():
+		assert.False(t, ok, "ReceiveC should be closed after Stop with concurrent senders")
+	case <-time.After(time.Second):
+		assert.Fail(t, "ReceiveC was not closed")
+	}
+}
+
 // AssertMailboxInvariantsAsync is helper functions that asserts mailbox invariants.
 func AssertMailboxInvariantsAsync(t *testing.T, mFact func() Mailbox[any]) {
 	t.Helper()


### PR DESCRIPTION
this pr fixes potential race condition scenario when `Stop()` is called while one goroutine is in `Send()`:
- `Stop()` closes `stopSigC` and calls `closeReceiveC()`; since `ongoingSend == 1`, doesn't close `c`
- sender wakes up, runs `defers: closeReceiveC()` first (still sees `ongoingSend == 1`), then decrements to 0.
- nobody ever calls `closeReceiveC()` again. channel never closes.