### PR TITLE
chore: allow zero Option

### DIFF
--- a/actor/actor_test.go
+++ b/actor/actor_test.go
@@ -54,6 +54,7 @@ func Test_Actor_New_NilOption(t *testing.T) {
 	t.Parallel()
 
 	var opt Option
+
 	w := NewWorker(func(Context) WorkerStatus {
 		return WorkerEnd
 	})

--- a/actor/actor_test.go
+++ b/actor/actor_test.go
@@ -50,6 +50,19 @@ func Test_Actor_New(t *testing.T) {
 	assertNoWork(t, w.doWorkC)
 }
 
+func Test_Actor_New_NilOption(t *testing.T) {
+	t.Parallel()
+
+	var opt Option
+	w := NewWorker(func(Context) WorkerStatus {
+		return WorkerEnd
+	})
+
+	assert.NotPanics(t, func() {
+		_ = New(w, opt)
+	})
+}
+
 // Test asserts that restarting actor will not impact worker's state.
 func Test_Actor_Restart(t *testing.T) {
 	t.Parallel()

--- a/actor/options.go
+++ b/actor/options.go
@@ -180,6 +180,10 @@ func newOptions[T ~func(o *options)](opts []T) options {
 	o := &options{}
 
 	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+
 		opt(o)
 	}
 

--- a/actor/options_test.go
+++ b/actor/options_test.go
@@ -17,6 +17,7 @@ func TestOptions(t *testing.T) {
 	testActorOptions(t)
 	testMailboxOptions(t)
 	testCombinedOptions(t)
+	testNilOptions(t)
 }
 
 func testActorOptions(t *testing.T) {
@@ -100,6 +101,41 @@ func testCombinedOptions(t *testing.T) {
 	{ // Assert that OnStopCombined will be set
 		opts := NewOptions(OptOnStopCombined(func() {}))
 		assert.NotNil(t, opts.Combined.OnStopFunc)
+
+		assert.Empty(t, opts.Actor)
+		assert.Empty(t, opts.Mailbox)
+	}
+}
+
+func testNilOptions(t *testing.T) {
+	t.Helper()
+
+	{ // Assert that nil actor options will be ignored
+		var opt Option
+		opts := NewOptions(opt, OptOnStart(func(Context) {}))
+
+		assert.NotNil(t, opts.Actor.OnStartFunc)
+		assert.Nil(t, opts.Actor.OnStopFunc)
+
+		assert.Empty(t, opts.Mailbox)
+		assert.Empty(t, opts.Combined)
+	}
+
+	{ // Assert that nil mailbox options will be ignored
+		var opt MailboxOption
+		opts := NewOptions(opt, OptCapacity(16))
+
+		assert.Equal(t, 16, opts.Mailbox.Capacity)
+
+		assert.Empty(t, opts.Actor)
+		assert.Empty(t, opts.Combined)
+	}
+
+	{ // Assert that nil combined options will be ignored
+		var opt CombinedOption
+		opts := NewOptions(opt, OptStopTogether())
+
+		assert.True(t, opts.Combined.StopTogether)
 
 		assert.Empty(t, opts.Actor)
 		assert.Empty(t, opts.Mailbox)


### PR DESCRIPTION
this PR allows zero options to be passed to `actor.New`. this enables following pattern:

```
var opt actor.Option

if callback != nil {
	opt = actor.OptOnStart(callback)
}

a := actor.New(w, opt) // ok even when callback == nil
```